### PR TITLE
Advent Pro: Version 3.000 added



### DIFF
--- a/ofl/adventpro/DESCRIPTION.en_us.html
+++ b/ofl/adventpro/DESCRIPTION.en_us.html
@@ -4,9 +4,6 @@
     give an edge to your typography.
 </p>
 <p>
-    The family was upgraded to a variable font with additional Italic styles in December 2022.
-    The spacing and kerning was improved, which could lead to a slightly different text line length than the previous version.
-</p>
-<p>
-    To contribute, see <a href="https://github.com/googlefonts/Advent">github.com/googlefonts/Advent</a>.
+    To contribute to the project, please see <a
+        href="https://github.com/googlefonts/Advent">github.com/googlefonts/Advent</a>.
 </p>

--- a/ofl/adventpro/METADATA.pb
+++ b/ofl/adventpro/METADATA.pb
@@ -24,6 +24,7 @@ fonts {
 subsets: "cyrillic"
 subsets: "cyrillic-ext"
 subsets: "greek"
+subsets: "greek-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
@@ -40,6 +41,23 @@ axes {
 source {
   repository_url: "https://github.com/googlefonts/Advent"
   commit: "d206a139ee9045993fbd1e530b93f28f8bf4e3b1"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/variable/split/AdventPro[wdth,wght].ttf"
+    dest_file: "AdventPro[wdth,wght].ttf"
+  }
+  files {
+    source_file: "fonts/variable/split/AdventPro-Italic[wdth,wght].ttf"
+    dest_file: "AdventPro-Italic[wdth,wght].ttf"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  branch: "master"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/googlefonts/Advent at commit d206a139ee9045993fbd1e530b93f28f8bf4e3b1.