### PR TITLE
Orbit: Version 1.000; ttfautohint (v1.8.4.7-5d5b);gftools[0.9.29] added



### DIFF
--- a/ofl/orbit/DESCRIPTION.en_us.html
+++ b/ofl/orbit/DESCRIPTION.en_us.html
@@ -1,7 +1,7 @@
 <p>
-    Orbit is inspired by the concept of monospaced Latin coding fonts. Korean fonts are usually already monospaced, but by bringing the impression of the Latin coding font in the Hangeul and punctuation design, Orbit gives a mathematical and geometric impression through a serif with right angle and orbicular circles. The font attempts to express orbitals with typeface using symmetry and connectivity to create a somewhat cosmic and futuristic atmosphere. As it is reminiscent of coding interface screens, it is recommended to use bright writing on a dark background, below 10pt.
+    Orbit is inspired by the concept of monospaced Latin coding fonts. Korean fonts are usually already monospaced, but by bringing the impression of the Latin coding font in the Hangeul and punctuation design, Orbit gives a mathematical and geometric impression through a serif with right angle and orbicular circles. The font attempts to express orbitals with typeface using symmetry and connectivity to create a somewhat cosmic and futuristic atmosphere. As it is reminiscent of coding interface screens, it is recommended to use bright writing on a dark background, below 10pt.
 </p>
 <p>
     To contribute, please visit <a
-        href="https://github.com/JAMO-TYPEFACE/Orbit">github.com/JAMO-TYPEFACE/Orbit</a>.
+        href="https://github.com/JAMO-TYPEFACE/Orbit">https://github.com/JAMO-TYPEFACE/Orbit</a>.
 </p>

--- a/ofl/orbit/METADATA.pb
+++ b/ofl/orbit/METADATA.pb
@@ -18,6 +18,19 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/JAMO-TYPEFACE/Orbit"
-  commit: "9f58ea557b9b3fd068f61f355f742fb58e741966"
+  commit: "95122395c6d1fda07aebdf36f566a75678bc3bdd"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "Fonts/ttf/Orbit-Regular.ttf"
+    dest_file: "Orbit-Regular.ttf"
+  }
+  branch: "main"
 }
 primary_script: "Kore"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/JAMO-TYPEFACE/Orbit at commit https://github.com/JAMO-TYPEFACE/Orbit/commit/95122395c6d1fda07aebdf36f566a75678bc3bdd.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
