### PR TITLE
Fleur De Leah: Version 1.010; ttfautohint (v1.8.3) added



### DIFF
--- a/ofl/fleurdeleah/DESCRIPTION.en_us.html
+++ b/ofl/fleurdeleah/DESCRIPTION.en_us.html
@@ -1,5 +1,5 @@
 <p>
-Fleur De Leah is a formal script with a floral flavour. One of the first fonts to incorporate embellishment design elements within the letterforms. 
+FleurDeLeah is a formal script with a floral flavour. One of the first fonts to incorporate embellishment design elements within the letterforms. 
 </p>
 <p>
 Use it sparingly for captions and short phrases and as with any script font, but <strong>never</strong> use it in all caps. Enjoy!

--- a/ofl/fleurdeleah/METADATA.pb
+++ b/ofl/fleurdeleah/METADATA.pb
@@ -12,9 +12,27 @@ fonts {
   full_name: "Fleur De Leah Regular"
   copyright: "Copyright 2008-2021 The Fleur De Leah Project Authors (https://github.com/googlefonts/fleurdeleah)"
 }
+subsets: "greek-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "vietnamese"
+source {
+  repository_url: "https://github.com/googlefonts/fleurdeleah"
+  commit: "69626faaf6a596ea822d4b0fd9521a506b9ffcc0"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "fonts/ttf/FleurDeLeah-Regular.ttf"
+    dest_file: "FleurDeLeah-Regular.ttf"
+  }
+  branch: "master"
+}
 classifications: "DISPLAY"
 classifications: "HANDWRITING"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/googlefonts/fleurdeleah at commit https://github.com/googlefonts/fleurdeleah/commit/69626faaf6a596ea822d4b0fd9521a506b9ffcc0.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
