### PR TITLE
Splash: Version 1.010; ttfautohint (v1.8.4.7-5d5b) added



### DIFF
--- a/ofl/splash/DESCRIPTION.en_us.html
+++ b/ofl/splash/DESCRIPTION.en_us.html
@@ -1,5 +1,5 @@
 <p>
-Inspired by the splatters that come from a heavily inked architectural ruling pen gliding along the surface of a highly textured watercolor page — Splash! Just as water droplets splash the ocean’s shore, no two splashes are exactly alike. The result is wonderfully organic and natural.
+Inspired by the splatters that come from a heavily inked architectural ruling pen gliding along the surface of a highly textured watercolor page— Splash! Just as water droplets splash the ocean’s shore, little control can be predicted and no two splashes are exactly alike. The result is wonderfully organic and natural surprises.
 </p>
 <p>
 It comes with Latin Character sets including Western, Central, and Vietnamese language support.

--- a/ofl/splash/METADATA.pb
+++ b/ofl/splash/METADATA.pb
@@ -12,6 +12,7 @@ fonts {
   full_name: "Splash Regular"
   copyright: "Copyright 2017-2021 The Splash Project Authors (https://github.com/googlefonts/splash)"
 }
+subsets: "greek-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
@@ -19,6 +20,19 @@ subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/splash"
   commit: "7653a0b5fcccd37a920ba9a4da8f1680c0203af2"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "documentation/DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "fonts/ttf/Splash-Regular.ttf"
+    dest_file: "Splash-Regular.ttf"
+  }
+  branch: "master"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/googlefonts/splash at commit https://github.com/googlefonts/splash/commit/7653a0b5fcccd37a920ba9a4da8f1680c0203af2.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
