### PR TITLE
Frank Ruhl Libre: Version 6.004 added



### DIFF
--- a/ofl/frankruhllibre/METADATA.pb
+++ b/ofl/frankruhllibre/METADATA.pb
@@ -24,5 +24,14 @@ axes {
 source {
   repository_url: "https://github.com/fontef/frankruhllibre"
   commit: "2372d1998e51dc011f86554c0d23f1ccf44afddf"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/variable/FrankRuhlLibre[wght].ttf"
+    dest_file: "FrankRuhlLibre[wght].ttf"
+  }
+  branch: "master"
 }
 stroke: "SERIF"

--- a/ofl/frankruhllibre/OFL.txt
+++ b/ofl/frankruhllibre/OFL.txt
@@ -2,7 +2,7 @@ Copyright 2015 The Frank Ruhl Libre Project Authors (https://github.com/fontef/f
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:
-https://openfontlicense.org
+https://scripts.sil.org/OFL
 
 
 -----------------------------------------------------------


### PR DESCRIPTION
Taken from the upstream repo https://github.com/fontef/frankruhllibre at commit https://github.com/fontef/frankruhllibre/commit/2372d1998e51dc011f86554c0d23f1ccf44afddf.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
