### PR TITLE
Meow Script: Version 1.010; ttfautohint (v1.8.3) added



### DIFF
--- a/ofl/meowscript/DESCRIPTION.en_us.html
+++ b/ofl/meowscript/DESCRIPTION.en_us.html
@@ -1,5 +1,5 @@
 <p>
-Meow Script is a monoline font with a number of alternate forms in six stylistic sets. It works eclectically and harmoniously to add a fun, whimsy look to your posters, ads, invitations and similar designs.
+Meow Script works is a monoline font with a number of alternate forms in six stylistic sets. It works eclectically and harmoniously to add a fun, whimsy look to your posters, ads, invitations and similar designs.
 </p>
 <p>
 It comes with Latin Character sets including Western, Central, and Vietnamese language support.

--- a/ofl/meowscript/METADATA.pb
+++ b/ofl/meowscript/METADATA.pb
@@ -12,7 +12,25 @@ fonts {
   full_name: "Meow Script Regular"
   copyright: "Copyright 2017 The Meow Script Project Authors (https://github.com/googlefonts/meow-script)"
 }
+subsets: "greek-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "vietnamese"
+source {
+  repository_url: "https://github.com/googlefonts/meow-script"
+  commit: "6882d389cb287bd7b7716c125e9728b81ed0ab41"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "fonts/ttf/MeowScript-Regular.ttf"
+    dest_file: "MeowScript-Regular.ttf"
+  }
+  branch: "master"
+}


### PR DESCRIPTION
Taken from the upstream repo https://github.com/googlefonts/meow-script at commit https://github.com/googlefonts/meow-script/commit/6882d389cb287bd7b7716c125e9728b81ed0ab41.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
