### PR TITLE
Wavefont: Version 3.005;gftools[0.9.33] added



### DIFF
--- a/ofl/wavefont/AUTHORS.txt
+++ b/ofl/wavefont/AUTHORS.txt
@@ -1,0 +1,8 @@
+# This is the official list of project authors for copyright purposes.
+# This file is distinct from the CONTRIBUTORS.txt file.
+# See the latter for an explanation.
+#
+# Names should be added to this file as:
+# Name or Organization <email address>
+
+Dmitry Iv. <df.creative@gmail.com>

--- a/ofl/wavefont/METADATA.pb
+++ b/ofl/wavefont/METADATA.pb
@@ -12,6 +12,9 @@ fonts {
   full_name: "Wavefont Thin"
   copyright: "Copyright 2022 The Wavefont Project Authors (https://github.com/dy/wavefont)"
 }
+subsets: "greek-ext"
+subsets: "latin"
+subsets: "latin-ext"
 subsets: "menu"
 axes {
   tag: "ROND"
@@ -38,7 +41,16 @@ registry_default_overrides {
 }
 source {
   repository_url: "https://github.com/dy/wavefont"
-  commit: "91649d7bede2a302b8b820dbccc2401672400cdd"
+  commit: "f53612d89500dabcb4bd35be3564f09e40e3255c"
+  files {
+    source_file: "AUTHORS.txt"
+    dest_file: "AUTHORS.txt"
+  }
+  files {
+    source_file: "fonts/variable/Wavefont[ROND,YELA,wght].ttf"
+    dest_file: "Wavefont[ROND,YELA,wght].ttf"
+  }
+  branch: "master"
 }
 sample_text {
   masthead_full: "111198765432111987654432111"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/dy/wavefont at commit https://github.com/dy/wavefont/commit/f53612d89500dabcb4bd35be3564f09e40e3255c.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
