### PR TITLE
Ruthie: Version 1.012 added



### DIFF
--- a/ofl/ruthie/DESCRIPTION.en_us.html
+++ b/ofl/ruthie/DESCRIPTION.en_us.html
@@ -2,5 +2,5 @@
 Ruthie is an elegant calligraphic script with ornate capital forms. 
 </p>
 <p>
-To contribute, see <a href="https://github.com/googlefonts/ruthie">github.com/googlefonts/ruthie</a>.
+To contribute, see <a href="https://github.com/googlefonts/ruthie" target="_blank">github.com/googlefonts/ruthie</a>.
 </p>

--- a/ofl/ruthie/METADATA.pb
+++ b/ofl/ruthie/METADATA.pb
@@ -12,9 +12,27 @@ fonts {
   full_name: "Ruthie Regular"
   copyright: "Copyright 2014 The Ruthie Project Authors (https://github.com/googlefonts/ruthie)"
 }
+subsets: "greek-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "vietnamese"
+source {
+  repository_url: "https://github.com/googlefonts/ruthie"
+  commit: "73c981515aaf81ab6b027f7e10716f6be62c3fd5"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "fonts/ttf/Ruthie-Regular.ttf"
+    dest_file: "Ruthie-Regular.ttf"
+  }
+  branch: "master"
+}
 classifications: "DISPLAY"
 classifications: "HANDWRITING"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/googlefonts/ruthie at commit https://github.com/googlefonts/ruthie/commit/73c981515aaf81ab6b027f7e10716f6be62c3fd5.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
