### PR TITLE
Albert Sans: Version 1.025 added



### DIFF
--- a/ofl/albertsans/METADATA.pb
+++ b/ofl/albertsans/METADATA.pb
@@ -31,5 +31,18 @@ axes {
 }
 source {
   repository_url: "https://github.com/usted/Albert-Sans"
-  commit: "929c7d5058afd06870d1dd4ebc3a0ee98bb77420"
+  commit: "d6bdf326c44694d3082e25d3caea355700eae380"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/variable/AlbertSans[wght].ttf"
+    dest_file: "AlbertSans[wght].ttf"
+  }
+  files {
+    source_file: "fonts/variable/AlbertSans-Italic[wght].ttf"
+    dest_file: "AlbertSans-Italic[wght].ttf"
+  }
+  branch: "main"
 }

--- a/ofl/albertsans/OFL.txt
+++ b/ofl/albertsans/OFL.txt
@@ -1,4 +1,4 @@
-Copyright 2021 The Albert Sans Project Authors (https://github.com/usted/Albert-Sans)
+Copyright 2023 The Albert Sans Project Authors (https://github.com/usted/Albert-Sans)
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:


### PR DESCRIPTION
Taken from the upstream repo https://github.com/usted/Albert-Sans at commit https://github.com/usted/Albert-Sans/commit/d6bdf326c44694d3082e25d3caea355700eae380.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
