### PR TITLE
Advent Pro: Version 3.000 added



### DIFF
--- a/ofl/adventpro/DESCRIPTION.en_us.html
+++ b/ofl/adventpro/DESCRIPTION.en_us.html
@@ -4,9 +4,6 @@
     give an edge to your typography.
 </p>
 <p>
-    The family was upgraded to a variable font with additional Italic styles in December 2022.
-    The spacing and kerning was improved, which could lead to a slightly different text line length than the previous version.
-</p>
-<p>
-    To contribute, see <a href="https://github.com/googlefonts/Advent">github.com/googlefonts/Advent</a>.
+    To contribute to the project, please see <a
+        href="https://github.com/googlefonts/Advent">github.com/googlefonts/Advent</a>.
 </p>

--- a/ofl/adventpro/METADATA.pb
+++ b/ofl/adventpro/METADATA.pb
@@ -24,6 +24,7 @@ fonts {
 subsets: "cyrillic"
 subsets: "cyrillic-ext"
 subsets: "greek"
+subsets: "greek-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
@@ -40,6 +41,23 @@ axes {
 source {
   repository_url: "https://github.com/googlefonts/Advent"
   commit: "d206a139ee9045993fbd1e530b93f28f8bf4e3b1"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/variable/split/AdventPro[wdth,wght].ttf"
+    dest_file: "AdventPro[wdth,wght].ttf"
+  }
+  files {
+    source_file: "fonts/variable/split/AdventPro-Italic[wdth,wght].ttf"
+    dest_file: "AdventPro-Italic[wdth,wght].ttf"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  branch: "master"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/googlefonts/Advent at commit https://github.com/googlefonts/Advent/commit/d206a139ee9045993fbd1e530b93f28f8bf4e3b1.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
