### PR TITLE
Noto Sans NKo Unjoined: Version 2.004 added



### DIFF
--- a/ofl/notosansnkounjoined/METADATA.pb
+++ b/ofl/notosansnkounjoined/METADATA.pb
@@ -12,6 +12,8 @@ fonts {
   full_name: "Noto Sans NKo Unjoined Regular"
   copyright: "Copyright 2023 The Noto Project Authors (https://github.com/notofonts/nko)"
 }
+subsets: "cyrillic-ext"
+subsets: "greek-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
@@ -22,8 +24,26 @@ axes {
   max_value: 700.0
 }
 source {
-  repository_url: "https://github.com/notofonts/nko.git"
+  repository_url: "https://github.com/notofonts/nko"
+  commit: "dada5d43b9ae33ff5a1993b200f4e1cf580cd974"
   archive_url: "https://github.com/notofonts/nko/releases/download/NotoSansNKoUnjoined-v2.004/NotoSansNKoUnjoined-v2.004.zip"
+  files {
+    source_file: "ARTICLE.en_us.html"
+    dest_file: "article/ARTICLE.en_us.html"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "NotoSansNKoUnjoined/googlefonts/variable-ttf/NotoSansNKoUnjoined[wght].ttf"
+    dest_file: "NotoSansNKoUnjoined[wght].ttf"
+  }
+  branch: "main"
 }
 is_noto: true
 languages: "bm_Nkoo"  # Bambara, Nko

--- a/ofl/notosansnkounjoined/article/ARTICLE.en_us.html
+++ b/ofl/notosansnkounjoined/article/ARTICLE.en_us.html
@@ -1,10 +1,10 @@
 <p>
-  Noto Sans N’Ko Unjoined is an unmodulated (“sans serif”) design for display texts in the African
+  Noto Sans NKo Unjoined is an unmodulated (“sans serif”) design for display texts in the African
   <em>N’Ko</em> script.
 </p>
 <p>
-  Noto Sans N’Ko Unjoined contains 184 glyphs, 5 OpenType features, and supports 79
-  characters from 2 Unicode blocks: N’Ko, Arabic.
+  Noto Sans NKo Unjoined contains 184 glyphs, 5 OpenType features, and supports 79
+  characters from 2 Unicode blocks: NKo, Arabic.
 </p>
 <h3>Supported writing systems</h3>
 <h4>N’Ko</h4>


### PR DESCRIPTION
Taken from the upstream repo https://github.com/notofonts/nko at commit https://github.com/notofonts/nko/commit/dada5d43b9ae33ff5a1993b200f4e1cf580cd974.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
