### PR TITLE
Sedan SC: Version 1.100; ttfautohint (v1.8.4.7-5d5b) added



### DIFF
--- a/ofl/sedansc/DESCRIPTION.en_us.html
+++ b/ofl/sedansc/DESCRIPTION.en_us.html
@@ -1,23 +1,12 @@
-<p>
- Sedan is a Garalde typeface prized for its timeless elegance, perfect for enhancing publications.
- With balanced proportions, subtle contrasts, and graceful serifs, Sedan offer both clarity and sophistication.
- Its versatility makes it ideal for various print materials, from magazines to scholarly journals, ensuring text remains inviting and accessible while exuding classic charm.
- Sedan embodies the enduring allure of Garalde designs in publishing.
-</p>
-<p>
- <a href="http://www.google.com/fonts/specimen/Sedan+SC">
-  Sedan SC
- </a>
- is also available, a small caps sister family next to the Roman and Italic
- <a href="http://www.google.com/fonts/specimen/Sedan">
-  Sedan
- </a>
- .
-</p>
-<p>
- To contribute, see
- <a href="https://github.com/googlefonts/sedan" target="_blank">
-  github.com/googlefonts/sedan
- </a>
- .
+<p>Sedan is a Garalde typeface prized for its timeless elegance, perfect for enhancing publications. With balanced
+    proportions, subtle contrasts, and graceful serifs, Sedan offer both clarity and sophistication. Its versatility
+    makes it ideal for various print materials, from magazines to scholarly journals, ensuring text remains inviting and
+    accessible while exuding classic charm. Sedan embodies the enduring allure of Garalde designs in publishing.</p>
+
+<p><a href="http://www.google.com/fonts/specimen/Sedan+SC">Sedan SC</a>
+    is also available, a small caps sister family next to the Roman and Italic <a
+        href="http://www.google.com/fonts/specimen/Sedan">Sedan</a>.</p>
+
+<p>To contribute, see
+    <a href="https://github.com/googlefonts/sedan" target="_blank">github.com/googlefonts/sedan</a>.
 </p>

--- a/ofl/sedansc/METADATA.pb
+++ b/ofl/sedansc/METADATA.pb
@@ -18,6 +18,19 @@ subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/sedan"
   commit: "35a4019d7c2547b58177cff9a65b91e47dd79546"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/SedanSC-Regular.ttf"
+    dest_file: "SedanSC-Regular.ttf"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  branch: "main"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/googlefonts/sedan at commit https://github.com/googlefonts/sedan/commit/35a4019d7c2547b58177cff9a65b91e47dd79546.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
