### PR TITLE
Madimi One: Version 1.000; ttfautohint (v1.8.4.7-5d5b) added



### DIFF
--- a/ofl/madimione/DESCRIPTION.en_us.html
+++ b/ofl/madimione/DESCRIPTION.en_us.html
@@ -1,3 +1,12 @@
-<p>Madimi is a rounded sans with a mixed geometric and organic design. The design covers all of Google Latin Core. Madimi takes inspiration from the gentle curved geometry of certain Southern Afrikan graphic symbols. Circles are a main feature, the circle being a shape that represents the womb of a woman in KiNtu symbologies. The idea behind Madimi is to enact the subtle visual subtext of Afrikan visual traditions. Madimi is simple, clean and round edged but still remains clear and easy to read.</p>
-
-<p>To contribute, see <a href="https://github.com/TaVaTake/madimi">github.com/TaVaTake/madimi</a>.</p>
+<p>
+    Please add a text describing the font here, 100 chracters or more, but no more than 500 words.
+    See https://googlefonts.github.io/gf-guide/description.html for further reference.
+    Please make sure that HTML characters are properly encoded. ('&' becomes &amp; etc.)
+    If unsure, use https://www.freeformatter.com/html-escape.html for formatting. (Use "Escape HTML").
+</p>
+<p>
+    Could be several paragraphs, also.
+</p>
+<p>
+    To contribute, see <a href="https://github.com/youruseraccount/yourrepository">github.com/youruseraccount/yourrepository</a>.
+</p>

--- a/ofl/madimione/METADATA.pb
+++ b/ofl/madimione/METADATA.pb
@@ -20,6 +20,19 @@ subsets: "symbols"
 source {
   repository_url: "https://github.com/TaVaTake/madimi"
   commit: "b0fedf3bfa1ac17a00bdbcbf06e8fe2aecfa009e"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "fonts/ttf/MadimiOne-Regular.ttf"
+    dest_file: "MadimiOne-Regular.ttf"
+  }
+  branch: "main"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/TaVaTake/madimi at commit https://github.com/TaVaTake/madimi/commit/b0fedf3bfa1ac17a00bdbcbf06e8fe2aecfa009e.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
