### PR TITLE
Platypi: Version 1.200 added



### DIFF
--- a/ofl/platypi/METADATA.pb
+++ b/ofl/platypi/METADATA.pb
@@ -33,5 +33,18 @@ axes {
 source {
   repository_url: "https://github.com/d-sargent/platypi"
   commit: "8574bbbc965e398a8c3da7edd926edda82b63113"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/variable/Platypi[wght].ttf"
+    dest_file: "Platypi[wght].ttf"
+  }
+  files {
+    source_file: "fonts/variable/Platypi-Italic[wght].ttf"
+    dest_file: "Platypi-Italic[wght].ttf"
+  }
+  branch: "main"
 }
-stroke:"SERIF"
+stroke: "SERIF"

--- a/ofl/platypi/OFL.txt
+++ b/ofl/platypi/OFL.txt
@@ -2,7 +2,7 @@ Copyright 2024 The Platypi Project Authors (https://github.com/d-sargent/platypi
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:
-https://openfontlicense.org
+https://scripts.sil.org/OFL
 
 
 -----------------------------------------------------------


### PR DESCRIPTION
Taken from the upstream repo https://github.com/d-sargent/platypi at commit https://github.com/d-sargent/platypi/commit/8574bbbc965e398a8c3da7edd926edda82b63113.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
