### PR TITLE
Noto Serif Hentaigana: Version 1.000 added



### DIFF
--- a/ofl/notoserifhentaigana/DESCRIPTION.en_us.html
+++ b/ofl/notoserifhentaigana/DESCRIPTION.en_us.html
@@ -1,5 +1,3 @@
 <p>
- Noto is a global font collection for writing in all modern and ancient languages.
- Noto Serif Hentaigana is a font that contains symbols for the Kana Supplement Unicode block.
- It has 478 glyphs.
+  Noto is a global font collection for writing in all modern and ancient languages. Noto Serif Hentaigana is a font that contains symbols for the Kana Supplement Unicode block. It has 478 glyphs.
 </p>

--- a/ofl/notoserifhentaigana/METADATA.pb
+++ b/ofl/notoserifhentaigana/METADATA.pb
@@ -21,8 +21,26 @@ axes {
   max_value: 900.0
 }
 source {
-  repository_url: "https://github.com/notofonts/hentaigana.git"
+  repository_url: "https://github.com/notofonts/hentaigana"
+  commit: "99817e142947b5cc5b8c140ad01d63f73fea1855"
   archive_url: "https://github.com/notofonts/hentaigana/releases/download/NotoSerifHentaigana-v1.000/NotoSerifHentaigana-v1.000.zip"
+  files {
+    source_file: "ARTICLE.en_us.html"
+    dest_file: "article/ARTICLE.en_us.html"
+  }
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "NotoSerifHentaigana/googlefonts/variable/NotoSerifHentaigana[wght].ttf"
+    dest_file: "NotoSerifHentaigana[wght].ttf"
+  }
+  branch: "main"
 }
 is_noto: true
 primary_script: "Hira"

--- a/ofl/notoserifhentaigana/OFL.txt
+++ b/ofl/notoserifhentaigana/OFL.txt
@@ -1,8 +1,8 @@
-Copyright 2023 The Noto Project Authors (https://github.com/notofonts/hentaigana)
+Copyright 2023 The Noto Project Authors (https://github.com/notofonts/noto-project-template)
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:
-https://openfontlicense.org
+https://scripts.sil.org/OFL
 
 
 -----------------------------------------------------------

--- a/ofl/notoserifhentaigana/article/ARTICLE.en_us.html
+++ b/ofl/notoserifhentaigana/article/ARTICLE.en_us.html
@@ -2,5 +2,5 @@
   Noto is a global font collection for writing in all modern and ancient languages. Noto Serif Hentaigana is a font that contains symbols for the Kana Supplement Unicode block.
 </p>
 <p>
-  Noto Serif Hentaigana contains 478 glyphs, and supports 515 characters from 9 Unicode blocks: Kana Supplement, Latin Extended-A, Basic Latin, Latin-1 Supplement, Combining Diacritical Marks, General Punctuation, Spacing Modifier Letters, Latin Extended Additional, Latin Extended-B.
+  Noto Znamenny Musical Notation contains 478 glyphs, and supports 515 characters from 9 Unicode blocks: Kana Supplement, Latin Extended-A, Basic Latin, Latin-1 Supplement, Combining Diacritical Marks, General Punctuation, Spacing Modifier Letters, Latin Extended Additional, Latin Extended-B.
 </p>


### PR DESCRIPTION
Taken from the upstream repo https://github.com/notofonts/hentaigana at commit https://github.com/notofonts/hentaigana/commit/99817e142947b5cc5b8c140ad01d63f73fea1855.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
