### PR TITLE
IBM Plex Sans Condensed: Version 1.3 added



### DIFF
--- a/ofl/ibmplexsanscondensed/DESCRIPTION.en_us.html
+++ b/ofl/ibmplexsanscondensed/DESCRIPTION.en_us.html
@@ -1,15 +1,13 @@
 <p>
-    IBM Plex® is the corporate typeface for IBM worldwide and an open-source project developed by the IBM Brand &amp;
-    Experience team (BX&amp;D). Plex is an international typeface family designed to capture IBM&rsquo;s brand spirit
-    and history and to illustrate the unique relationship between mankind and machine—a principal theme for IBM since
-    the turn of the century. The result is a neutral yet friendly Grotesque style typeface that balances design with the
-    engineered details that make Plex distinctly IBM. <a href="https://fonts.google.com/?query=ibm+plex"></a>The
-    family</a> includes a Sans, Sans Condensed, Mono, and Serif and has excellent legibility in print, web, and mobile
-    interfaces.
-</p>
-<p>
-    Plex&rsquo;s three designs work well independently and even better together. Use the Sans as a
-    contemporary compadre, the Serif for editorial storytelling, or the Mono to show code snippets. The unexpectedly
-    expressive nature of the italics gives you even more options for your designs. Currently, IBM Plex Sans supports
-    Extended Latin, Arabic, Cyrillic, Devanagari, Greek, Hebrew, Japanese, Korean and Thai.
+    IBM Plex™ is an international typeface family designed by Mike Abbink, IBM BX&amp;D, in collaboration with Bold
+    Monday, an independent Dutch type foundry.
+    Plex was designed to capture IBM’s spirit and history, and to illustrate the unique relationship between mankind and
+    machine—a principal theme for IBM since the turn of the century.
+    The result is a neutral, yet friendly Grotesque style typeface that includes a Sans, Sans Condensed, Mono, Serif,
+    and
+    <a href="https://fonts.google.com/?query=ibm+plex">several other styles for several languages</a>,
+    and has excellent legibility in print, web and mobile interfaces.
+    Plex’s three designs work well independently, and even better together.
+    Use the Sans as a contemporary compadre, the Serif for editorial storytelling, or the Mono to show code snippets.
+    The unexpectedly expressive nature of the italics give you even more options for your designs.
 </p>

--- a/ofl/ibmplexsanscondensed/METADATA.pb
+++ b/ofl/ibmplexsanscondensed/METADATA.pb
@@ -130,7 +130,77 @@ fonts {
   copyright: "Copyright 2019 IBM Corp. All rights reserved."
 }
 subsets: "cyrillic-ext"
+subsets: "greek-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "vietnamese"
+source {
+  repository_url: "https://github.com/googlefonts/plex"
+  commit: "94a30e0040996e382a997dd73be040b961e4512d"
+  files {
+    source_file: "LICENSE.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "Google-Fonts-Fixes/descriptions/DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "Google-Fonts-Fixes/fonts/IBM-Plex-Sans-Condensed/fonts/complete/ttf/IBMPlexSansCondensed-Bold.ttf"
+    dest_file: "IBMPlexSansCondensed-Bold.ttf"
+  }
+  files {
+    source_file: "Google-Fonts-Fixes/fonts/IBM-Plex-Sans-Condensed/fonts/complete/ttf/IBMPlexSansCondensed-BoldItalic.ttf"
+    dest_file: "IBMPlexSansCondensed-BoldItalic.ttf"
+  }
+  files {
+    source_file: "Google-Fonts-Fixes/fonts/IBM-Plex-Sans-Condensed/fonts/complete/ttf/IBMPlexSansCondensed-ExtraLight.ttf"
+    dest_file: "IBMPlexSansCondensed-ExtraLight.ttf"
+  }
+  files {
+    source_file: "Google-Fonts-Fixes/fonts/IBM-Plex-Sans-Condensed/fonts/complete/ttf/IBMPlexSansCondensed-ExtraLightItalic.ttf"
+    dest_file: "IBMPlexSansCondensed-ExtraLightItalic.ttf"
+  }
+  files {
+    source_file: "Google-Fonts-Fixes/fonts/IBM-Plex-Sans-Condensed/fonts/complete/ttf/IBMPlexSansCondensed-Italic.ttf"
+    dest_file: "IBMPlexSansCondensed-Italic.ttf"
+  }
+  files {
+    source_file: "Google-Fonts-Fixes/fonts/IBM-Plex-Sans-Condensed/fonts/complete/ttf/IBMPlexSansCondensed-Light.ttf"
+    dest_file: "IBMPlexSansCondensed-Light.ttf"
+  }
+  files {
+    source_file: "Google-Fonts-Fixes/fonts/IBM-Plex-Sans-Condensed/fonts/complete/ttf/IBMPlexSansCondensed-LightItalic.ttf"
+    dest_file: "IBMPlexSansCondensed-LightItalic.ttf"
+  }
+  files {
+    source_file: "Google-Fonts-Fixes/fonts/IBM-Plex-Sans-Condensed/fonts/complete/ttf/IBMPlexSansCondensed-Medium.ttf"
+    dest_file: "IBMPlexSansCondensed-Medium.ttf"
+  }
+  files {
+    source_file: "Google-Fonts-Fixes/fonts/IBM-Plex-Sans-Condensed/fonts/complete/ttf/IBMPlexSansCondensed-MediumItalic.ttf"
+    dest_file: "IBMPlexSansCondensed-MediumItalic.ttf"
+  }
+  files {
+    source_file: "Google-Fonts-Fixes/fonts/IBM-Plex-Sans-Condensed/fonts/complete/ttf/IBMPlexSansCondensed-Regular.ttf"
+    dest_file: "IBMPlexSansCondensed-Regular.ttf"
+  }
+  files {
+    source_file: "Google-Fonts-Fixes/fonts/IBM-Plex-Sans-Condensed/fonts/complete/ttf/IBMPlexSansCondensed-SemiBold.ttf"
+    dest_file: "IBMPlexSansCondensed-SemiBold.ttf"
+  }
+  files {
+    source_file: "Google-Fonts-Fixes/fonts/IBM-Plex-Sans-Condensed/fonts/complete/ttf/IBMPlexSansCondensed-SemiBoldItalic.ttf"
+    dest_file: "IBMPlexSansCondensed-SemiBoldItalic.ttf"
+  }
+  files {
+    source_file: "Google-Fonts-Fixes/fonts/IBM-Plex-Sans-Condensed/fonts/complete/ttf/IBMPlexSansCondensed-Thin.ttf"
+    dest_file: "IBMPlexSansCondensed-Thin.ttf"
+  }
+  files {
+    source_file: "Google-Fonts-Fixes/fonts/IBM-Plex-Sans-Condensed/fonts/complete/ttf/IBMPlexSansCondensed-ThinItalic.ttf"
+    dest_file: "IBMPlexSansCondensed-ThinItalic.ttf"
+  }
+  branch: "master"
+}


### PR DESCRIPTION
Taken from the upstream repo https://github.com/googlefonts/plex at commit https://github.com/googlefonts/plex/commit/94a30e0040996e382a997dd73be040b961e4512d.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
