### PR TITLE
Rubik Moonrocks: Version 2.200 added



### DIFF
--- a/ofl/rubikmoonrocks/DESCRIPTION.en_us.html
+++ b/ofl/rubikmoonrocks/DESCRIPTION.en_us.html
@@ -3,7 +3,7 @@
 </p>
 
 <p>
-Check for more <a href="https://fonts.google.com/?query=Rubik">Rubik "Filtered" fonts</a>!.
+Check for more <a href="https://fonts.google.com/?query=Rubik">Rubik "Filtered" fonts</a>!
 </p>
 
 <p>

--- a/ofl/rubikmoonrocks/METADATA.pb
+++ b/ofl/rubikmoonrocks/METADATA.pb
@@ -20,7 +20,20 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/NaN-xyz/Rubik-Filtered"
-  commit: "50fec619b373f40dfd839408e77c5b3a616e972d"
+  commit: "c89f25696f8c15d3c180b087256591d43d6f46db"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "moonrocks/fonts/ttf/RubikMoonrocks-Regular.ttf"
+    dest_file: "RubikMoonrocks-Regular.ttf"
+  }
+  files {
+    source_file: "documentation/DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  branch: "main"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/NaN-xyz/Rubik-Filtered at commit https://github.com/NaN-xyz/Rubik-Filtered/commit/c89f25696f8c15d3c180b087256591d43d6f46db.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
