### PR TITLE
Gajraj One: Version 1.000 added



### DIFF
--- a/ofl/gajrajone/DESCRIPTION.en_us.html
+++ b/ofl/gajrajone/DESCRIPTION.en_us.html
@@ -1,6 +1,4 @@
-<p>
-    Gajraj (the king of elephants) is a Latin display typeface with Devanagari language support, designed for use in large hoardings, 
-    signage, and print materials for branding and advertising. It is a single variant display typeface, created as the designer's 
-    first attempt at designing in the Devanagari script.
-</p>
+<p>Based in Udaipur, Rajasthan, India, Saurabh Sharma is an independent Frontend Developer & Graphic/Web design professional. With over 17 years of experience in the Information Technology and Services Industry, Saurabh has worked on HTML/CSS websites, UI Designs,
+Frameworks, WordPress themes, plugins, JavaScript and php projects. In recent years, Saurabh has been actively working on font design and development. His first release was the Kumbh Sans Project on Google fonts.
+
 <p>To contribute, see <a href="https://github.com/xconsau/GajrajOne">github.com/xconsau/GajrajOne</a>.</p>

--- a/ofl/gajrajone/METADATA.pb
+++ b/ofl/gajrajone/METADATA.pb
@@ -12,13 +12,28 @@ fonts {
   full_name: "Gajraj One Regular"
   copyright: "Copyright 2022 The GajrajOne Project Authors (https://github.com/xconsau/gajrajone)"
 }
+subsets: "cyrillic-ext"
 subsets: "devanagari"
+subsets: "greek-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/xconsau/GajrajOne"
   commit: "5768aa3d4522b402ead302e5bb8697e965da694f"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/GajrajOne-Regular.ttf"
+    dest_file: "GajrajOne-Regular.ttf"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  branch: "main"
 }
 primary_script: "Deva"
 stroke: "SANS_SERIF"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/xconsau/GajrajOne at commit https://github.com/xconsau/GajrajOne/commit/5768aa3d4522b402ead302e5bb8697e965da694f.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
