### PR TITLE
STIX Two Text: Version 2.13 b171 added



### DIFF
--- a/ofl/stixtwotext/DESCRIPTION.en_us.html
+++ b/ofl/stixtwotext/DESCRIPTION.en_us.html
@@ -2,7 +2,7 @@
 The Scientific and Technical Information eXchange (STIX) fonts are intended to satisfy the demanding needs of authors, publishers, printers, and others working in the scientific, medical, and technical fields.
 </p>
 <p>
-The STIX Two fonts consist of two variable text fonts (Roman and Italic), eight static text (Regular to Bold in both roman and italic variants) and one Math font (currently only available for direct download from the repository). Together, they provide a uniform set of fonts that can be used throughout the production process.
+The STIX Two fonts consist of one Math font, two variable text fonts (Roman and Italic), and eight static text (Regular to Bold in both roman and italic variants). Together, they provide a uniform set of fonts that can be used throughout the production process.
 </p>
 <p>
 The STIX project began through the joint efforts of American Mathematical Society (AMS), American Institute of Physics (AIP), American Physical Society (APS), American Chemical Society (ACS), The Institute of Electrical and Electronic Engineers (IEEE), and Elsevier. These companies are collectively known as the STI Pub companies.

--- a/ofl/stixtwotext/METADATA.pb
+++ b/ofl/stixtwotext/METADATA.pb
@@ -33,3 +33,24 @@ axes {
   min_value: 400.0
   max_value: 700.0
 }
+source {
+  repository_url: "https://github.com/stipub/stixfonts"
+  commit: "f120869ef6853e187514917dc8c2b99adfded140"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "fonts/variable_ttf/STIXTwoText[wght].ttf"
+    dest_file: "STIXTwoText[wght].ttf"
+  }
+  files {
+    source_file: "fonts/variable_ttf/STIXTwoText-Italic[wght].ttf"
+    dest_file: "STIXTwoText-Italic[wght].ttf"
+  }
+  branch: "master"
+}

--- a/ofl/stixtwotext/OFL.txt
+++ b/ofl/stixtwotext/OFL.txt
@@ -4,7 +4,6 @@ This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:
 http://scripts.sil.org/OFL
 
-
 -----------------------------------------------------------
 SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
 -----------------------------------------------------------


### PR DESCRIPTION
Taken from the upstream repo https://github.com/stipub/stixfonts at commit https://github.com/stipub/stixfonts/commit/f120869ef6853e187514917dc8c2b99adfded140.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
