### PR TITLE
Zen Old Mincho: Version 1.500 added



### DIFF
--- a/ofl/zenoldmincho/DESCRIPTION.en_us.html
+++ b/ofl/zenoldmincho/DESCRIPTION.en_us.html
@@ -1,18 +1,6 @@
 <p>
-    Zen Old Mincho is a Japanese mincho (serif) typeface with a classic design. This font family started with the regular (400) weight, and bold and black weights were added due to huge demand. The wide range of weights means while the design is intended
-    for text usage, it also works well in large sizes.
+    Zen Old Mincho is a basic text style Japanese serif (Mincho) family. This font family started with the weight “NR”, and added the rest of the weights due to huge demand. Wide range of weights could offer not only the text usage but also more various scenes and media.
 </p>
 <p>
-    To contribute to the project, visit <a href="https://github.com/googlefonts/zen-oldmincho">github.com/googlefonts/zen-oldmincho</a>
-</p>
-<p>
-    Zen Old Mincho はベーシックな本文用の日本語明朝体ファミリーです このフォントファミリーには、はじめは「Regular」の太さしかありませんでしたが、多くの要望にお応えして、他のウェイトも追加しました。使える太さの範囲が広いため、本文用だけでなく、その他さ まざまな場面やメディアでご利用いただけます。
-</p>
-<p>
-    このプロジェクトに参加して貢献したい方は、次の URL をご参照ください。
-    <a href="https://github.com/googlefonts/zen-oldmincho">github.com/googlefonts/zen-oldmincho</a>
-</p>
-<p>
-    To learn more, read <a href="https://fonts.googleblog.com/2021/10/say-hello-to-our-big-new-japanese.html">Say Hello to our big new Japanese collection with Zen Fonts</a>(English), <a href="https://fonts.googleblog.com/2021/10/the-story-of-zen-fonts-interview-with.html">The Story of Zen Fonts - interview with Yoshimichi Ohira</a>(English),
-    <a href="https://fonts.googleblog.com/2021/10/zen_0361327225.html">Zenフォント: 新しい日本語フォントコレクションの登場 - 日本語フォントの複雑な美しさについて -</a>(Japanese), and <a href="https://fonts.googleblog.com/2021/10/Japaneseinterview.html">Zenフォントのおはなし：大平善道さんとのインタビュー</a>(Japanese).
+To contribute to the project, visit <a href="https://github.com/googlefonts/zen-oldmincho">https://github.com/googlefonts/zen-oldmincho</a>
 </p>

--- a/ofl/zenoldmincho/METADATA.pb
+++ b/ofl/zenoldmincho/METADATA.pb
@@ -48,10 +48,46 @@ fonts {
   full_name: "Zen Old Mincho Black"
   copyright: "Copyright 2021 The Zen Old Mincho Project Authors (https://github.com/googlefonts/zen-oldmincho)"
 }
+subsets: "chinese-hongkong"
+subsets: "chinese-simplified"
+subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "greek"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
+source {
+  repository_url: "https://github.com/googlefonts/zen-oldmincho"
+  commit: "fb46620f2ffcf78debc1a20758e39271a3fb5ea6"
+  files {
+    source_file: "fonts/ttf/ZenOldMincho-Regular.ttf"
+    dest_file: "ZenOldMincho-Regular.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/ZenOldMincho-Medium.ttf"
+    dest_file: "ZenOldMincho-Medium.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/ZenOldMincho-SemiBold.ttf"
+    dest_file: "ZenOldMincho-SemiBold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/ZenOldMincho-Bold.ttf"
+    dest_file: "ZenOldMincho-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/ZenOldMincho-Black.ttf"
+    dest_file: "ZenOldMincho-Black.ttf"
+  }
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  branch: "main"
+}
 primary_script: "Jpan"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/googlefonts/zen-oldmincho at commit https://github.com/googlefonts/zen-oldmincho/commit/fb46620f2ffcf78debc1a20758e39271a3fb5ea6.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
