### PR TITLE
Kiwi Maru: Version 1.100 added



### DIFF
--- a/ofl/kiwimaru/DESCRIPTION.en_us.html
+++ b/ofl/kiwimaru/DESCRIPTION.en_us.html
@@ -1,5 +1,5 @@
 <p>
-Kiwi Maru was created mainly for use in digital devices, and I hope you will use it experimentally in your papers and reports.
+Kiwi Maru was created mainly for use in digital devices, and I hope you will use it experimentally in your web fonts, papers and reports.
 </p>
 <p>
 The basic vocabulary of the Japanese language is divided into three categories: "everyday words", which are used freely in everyday conversation, articles and novels, "written words", which are used in official situations and sentences, and "slang", which is more informal in style.

--- a/ofl/kiwimaru/METADATA.pb
+++ b/ofl/kiwimaru/METADATA.pb
@@ -30,8 +30,37 @@ fonts {
   full_name: "Kiwi Maru Medium"
   copyright: "Copyright 2020 The Kiwi Maru Project Authors (https://github.com/Kiwi-KawagotoKajiru/Kiwi-Maru)"
 }
+subsets: "chinese-hongkong"
+subsets: "chinese-simplified"
+subsets: "chinese-traditional"
 subsets: "cyrillic"
+subsets: "greek-ext"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
+source {
+  repository_url: "https://github.com/Kiwi-KawagotoKajiru/Kiwi-Maru"
+  commit: "65a112c7ec9ffe81595406982a670c7f945d7c5b"
+  files {
+    source_file: "fonts/ttf/KiwiMaru-Light.ttf"
+    dest_file: "KiwiMaru-Light.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/KiwiMaru-Medium.ttf"
+    dest_file: "KiwiMaru-Medium.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/KiwiMaru-Regular.ttf"
+    dest_file: "KiwiMaru-Regular.ttf"
+  }
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  branch: "master"
+}


### PR DESCRIPTION
Taken from the upstream repo https://github.com/Kiwi-KawagotoKajiru/Kiwi-Maru at commit https://github.com/Kiwi-KawagotoKajiru/Kiwi-Maru/commit/65a112c7ec9ffe81595406982a670c7f945d7c5b.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
