### PR TITLE
Palette Mosaic: Version 1.001 added



### DIFF
--- a/ofl/palettemosaic/DESCRIPTION.en_us.html
+++ b/ofl/palettemosaic/DESCRIPTION.en_us.html
@@ -1,11 +1,11 @@
 <p>
-Palette Mosaic is constructed from primitive shapes by handicapped artists in collaboration with design students. The shapes have been arranged to create a strong and solid atmosphere.
-</p>
-<p>
-This family is part of the Shibuya Font project, a collaboration of design major students and handicapped artist living in Shibuya city, officially approved by Shibuya city in Tokyo. 
+Design students produce fonts and graphic data based on the art drawn by people with disabilities. It is released as public data of Shibuya City official recognition. The adoption of wards and businesses has spread, making it a social action that leads to diversity understanding. The profits obtained from data sales are returned to the facilities for supporting people with disabilities.
 </p>
 <p>
 Shibuya font Official Site: <a href="http://www.shibuyafont.jp">http://www.shibuyafont.jp</a>
+</p>
+<p>
+Good Design Award 2019: <a href="https://www.g-mark.org/award/describe/49720">https://www.g-mark.org/award/describe/49720</a>
 </p>
 <p>
 To contribute to the project, visit <a href="https://github.com/shibuyafont/Palette-mosaic-font-mono">github.com/shibuyafont/Palette-mosaic-font-mono</a>

--- a/ofl/palettemosaic/METADATA.pb
+++ b/ofl/palettemosaic/METADATA.pb
@@ -17,6 +17,20 @@ subsets: "latin"
 subsets: "menu"
 source {
   repository_url: "https://github.com/shibuyafont/Palette-mosaic-font-mono"
+  commit: "461da4c5f2ca2d38a590d27468252b9b4a54e31f"
+  files {
+    source_file: "fonts/ttf/PaletteMosaic-Regular.ttf"
+    dest_file: "PaletteMosaic-Regular.ttf"
+  }
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  branch: "master"
 }
 languages: "ja_Kana"  # Japanese, Katakana
 languages: "ja_Hira"  # Japanese, Hiragana


### PR DESCRIPTION
Taken from the upstream repo https://github.com/shibuyafont/Palette-mosaic-font-mono at commit https://github.com/shibuyafont/Palette-mosaic-font-mono/commit/461da4c5f2ca2d38a590d27468252b9b4a54e31f.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
