### PR TITLE
Alumni Sans Pinstripe: Version 1.010; ttfautohint (v1.8.4.7-5d5b) added



### DIFF
--- a/ofl/alumnisanspinstripe/DESCRIPTION.en_us.html
+++ b/ofl/alumnisanspinstripe/DESCRIPTION.en_us.html
@@ -1,5 +1,5 @@
 <p>
-Alumni Pinstripe is a stand alone font from its base font, <a href="https://fonts.google.com/specimen/Alumni+Sans">Alumni Sans</a> (a variable font). Pinstripe is a super-thin weight and designed to be used as a display font above 32pt in print (assuming 300 dpi) and above 72px in digital media. In situations that require large text, use this Pinstripe variation in combination with the Alumni Sans base design.
+Alumni Pinstripe is a stand alone font from its base font, <a href="https://fonts.google.com/specimen/Alumni+Sans"></a>Alumni Sans</a> (a variable font). Pinstripe is a super-thin weight and designed to be used as a display font above 32pt in print (assuming 300 dpi) and above 72px in digital media. In situations that require large text, use this Pinstripe variation in combination with the Alumni Sans base design.
 </p>
 <p>
 It comes with Latin Character sets including Western, Central, and Vietnamese language support.

--- a/ofl/alumnisanspinstripe/METADATA.pb
+++ b/ofl/alumnisanspinstripe/METADATA.pb
@@ -24,6 +24,7 @@ fonts {
 }
 subsets: "cyrillic"
 subsets: "cyrillic-ext"
+subsets: "greek-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
@@ -31,6 +32,23 @@ subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/alumni-sans-pinstripe"
   commit: "26cf834f2eca219b017478be9ea1387c78756e78"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "documentation/DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "fonts/ttf/AlumniSansPinstripe-Regular.ttf"
+    dest_file: "AlumniSansPinstripe-Regular.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/AlumniSansPinstripe-Italic.ttf"
+    dest_file: "AlumniSansPinstripe-Italic.ttf"
+  }
+  branch: "main"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/googlefonts/alumni-sans-pinstripe at commit https://github.com/googlefonts/alumni-sans-pinstripe/commit/26cf834f2eca219b017478be9ea1387c78756e78.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
