### PR TITLE
Yuji Hentaigana Akebono: Version 3.002 added



### DIFF
--- a/ofl/yujihentaiganaakebono/DESCRIPTION.en_us.html
+++ b/ofl/yujihentaiganaakebono/DESCRIPTION.en_us.html
@@ -5,13 +5,5 @@
     As there are no Hentaigana for Katakana, no Katakana are included. Latin is all-caps / small caps. 
 </p>
 <p>
-    Fonts in the Yuji Family:
-<ul>
-<li><a href="https://fonts.google.com/specimen/Yuji+Hentaigana+Akari">Yuji Hentaigana Akari</a></li>
-<li><a href="https://fonts.google.com/specimen/Yuji+Boku">Yuji Boku</a></li>
-<li><a href="https://fonts.google.com/specimen/Yuji+Mai">Yuji Mai</a></li>
-<li><a href="https://fonts.google.com/specimen/Yuji+Syuku">Yuji Syuku</a></li>
-</ul></p>
-<p>
 To contribute to the project, visit <a href="https://github.com/Kinutafontfactory/Yuji">github.com/Kinutafontfactory/Yuji</a>
 </p>

--- a/ofl/yujihentaiganaakebono/METADATA.pb
+++ b/ofl/yujihentaiganaakebono/METADATA.pb
@@ -12,10 +12,28 @@ fonts {
   full_name: "Yuji Hentaigana Akebono Regular"
   copyright: "Copyright 2021 The Yuji Project Authors (https://github.com/Kinutafontfactory/Yuji)"
 }
+subsets: "greek-ext"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
+source {
+  repository_url: "https://github.com/Kinutafontfactory/Yuji"
+  commit: "efec977b14b57c19eb85d468edcfbbad13139e67"
+  files {
+    source_file: "fonts/ttf/YujiHentaiganaAkebono-Regular.ttf"
+    dest_file: "YujiHentaiganaAkebono-Regular.ttf"
+  }
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "akebono_DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  branch: "master"
+}
+languages: "ja_Kana"  # Japanese, Katakana
+languages: "ja_Hira"  # Japanese, Hiragana
 primary_script: "Hira"
-languages: "ja_Kana"
-languages: "ja_Hira"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/Kinutafontfactory/Yuji at commit https://github.com/Kinutafontfactory/Yuji/commit/efec977b14b57c19eb85d468edcfbbad13139e67.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
