### PR TITLE
AR One Sans: Version 1.001;gftools[0.9.33] added



### DIFF
--- a/ofl/aronesans/DESCRIPTION.en_us.html
+++ b/ofl/aronesans/DESCRIPTION.en_us.html
@@ -1,9 +1,9 @@
 <p>
-AR One Sans is a type family for use in augmented reality environments and user interfaces. The family's low contrast, generous spacing and robust shapes make it work well in busy backgrounds with high readability. The design of letterforms is based on research and thorough testing on various devices ranging from high-end headsets to low-resolution smartphone-based devices. It has optical weights for high and low-resolution duplexed to avoid text reflow, making it easy to deliver a seamless user experience across platforms/devices. The functionality of the text has been tested thoroughly to make the reading experience better even in longer texts.
+AR One Sans is a type family for use in augmented reality environments and user interfaces. It’s low contrast, generous spacing and robust shapes make it work well in busy backgrounds with high readability. The design of letterforms is based on research and thorough testing on various devices ranging from high-end headsets to low-resolution smartphone-based devices. It has optical weights for high and low-resolution duplexed to avoid text reflow, making it easy to deliver a seamless user experience across platforms/devices. The functionality of the text has been tested thoroughly to make the reading experience better even in longer texts.
 </p>
 <p>
 AR One Sans language support includes full coverage of Vietnamese, additional to all Western, Central, and South-Eastern European languages.
 </p>
 <p> 
-To contribute see <a href="https://github.com/niteeshy/ar-one-sans">github.com/niteeshy/ar-one-sans</a>.
+To contribute see <a href="https://github.com/niteeshy/ar-one-sans" target="_blank">github.com/niteeshy/ar-one-sans</a>.
 </p>

--- a/ofl/aronesans/METADATA.pb
+++ b/ofl/aronesans/METADATA.pb
@@ -28,6 +28,18 @@ axes {
 }
 source {
   repository_url: "https://github.com/niteeshy/ar-one-sans"
-  commit: "a463b112ca9393f1904765e0f32891b849eb9cf1"
+  commit: "bdeabbcf8e8c605b5d62de16ba687b36aeef6e35"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "documentation/DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "fonts/variable/AROneSans[ARRR,wght].ttf"
+    dest_file: "AROneSans[ARRR,wght].ttf"
+  }
+  branch: "main"
 }
-


### PR DESCRIPTION
Taken from the upstream repo https://github.com/niteeshy/ar-one-sans at commit https://github.com/niteeshy/ar-one-sans/commit/bdeabbcf8e8c605b5d62de16ba687b36aeef6e35.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
