### PR TITLE
Ole: Version 1.010; ttfautohint (v1.8.3) added



### DIFF
--- a/ofl/ole/DESCRIPTION.en_us.html
+++ b/ofl/ole/DESCRIPTION.en_us.html
@@ -1,6 +1,5 @@
 <p>
-Olé (named after the Spanish expression, pronounced "oh-leh!") has a romantic and fun flavour.
-Have a little fun using the ornamental glyphs to spice up any design.
+Olé (a Spanish expression, pronounced "ohle!") has a romantic and fun flavour. Have a little fun using the ornamental glyphs to spice up any design.
 </p>
 <p>
 The Latin glyph set supports Western, Central, Eastern european languages and also Vietnamese.

--- a/ofl/ole/METADATA.pb
+++ b/ofl/ole/METADATA.pb
@@ -12,7 +12,25 @@ fonts {
   full_name: "Ole Regular"
   copyright: "Copyright 2008 The Ole Project Authors (https://github.com/googlefonts/ole)"
 }
+subsets: "greek-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "vietnamese"
+source {
+  repository_url: "https://github.com/googlefonts/ole"
+  commit: "fe77f34a3002bc4c2e26a8e27bee31cb45307846"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "fonts/ttf/Ole-Regular.ttf"
+    dest_file: "Ole-Regular.ttf"
+  }
+  branch: "master"
+}


### PR DESCRIPTION
Taken from the upstream repo https://github.com/googlefonts/ole at commit https://github.com/googlefonts/ole/commit/fe77f34a3002bc4c2e26a8e27bee31cb45307846.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
