### PR TITLE
Arizonia: Version 1.010; ttfautohint (v1.8.4.7-5d5b) added



### DIFF
--- a/ofl/arizonia/DESCRIPTION.en_us.html
+++ b/ofl/arizonia/DESCRIPTION.en_us.html
@@ -1,5 +1,5 @@
 <p>
-Arizonia was inspired by the lettering found on a construction truck. It has a sign-painterly appearance which features thick and contrasting stokes that have been painted by a pointed brush. 
+Arizonia was inspired by the lettering found on a construction truck. It has a sign-painterly look with thick and then contrasts that resembles using a pointed brush. 
 </p>
 <p>
 It can be used for situations that require a hand lettered, contemporary and sporty feel. As with any script, Arizonia should not be used in ALL Caps.

--- a/ofl/arizonia/METADATA.pb
+++ b/ofl/arizonia/METADATA.pb
@@ -12,6 +12,7 @@ fonts {
   full_name: "Arizonia Regular"
   copyright: "Copyright 2007-2021 The Arizonia Project Authors (https://github.com/googlefonts/arizonia)"
 }
+subsets: "greek-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
@@ -19,6 +20,19 @@ subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/arizonia"
   commit: "e135e3351c17de6f0f12066e98d7af9abe1cd76e"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "documentation/DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "fonts/ttf/Arizonia-Regular.ttf"
+    dest_file: "Arizonia-Regular.ttf"
+  }
+  branch: "main"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/googlefonts/arizonia at commit https://github.com/googlefonts/arizonia/commit/e135e3351c17de6f0f12066e98d7af9abe1cd76e.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
