### PR TITLE
Zen Dots: Version 1.000; ttfautohint (v1.8.3) added



### DIFF
--- a/ofl/zendots/DESCRIPTION.en_us.html
+++ b/ofl/zendots/DESCRIPTION.en_us.html
@@ -1,8 +1,9 @@
 <p>
-Zen Dots Family is one of three Latin fonts designed by Yoshimichi Ohira, as part of the Zen Fonts collection.
+Zen Dots Family is one of three Latin fonts designed by Yoshimichi Ohira, as part of Zen Fonts collection.
 </p>
 <p>
-Zen Dots was designed with a futuristic vision and inspired by the different eras in science fiction films.
+Dots was designed with a futuristic vision. 
+This font is used to recognize different areas in science fiction films.
 </p>
 <p>
 To contribute, see <a href="https://github.com/googlefonts/zen-dots" target="_blank">github.com/googlefonts/zen-dots</a>.

--- a/ofl/zendots/METADATA.pb
+++ b/ofl/zendots/METADATA.pb
@@ -12,8 +12,26 @@ fonts {
   full_name: "Zen Dots Regular"
   copyright: "Copyright 2021 The Dots Project Authors (https://github.com/googlefonts/zen-dots)"
 }
+subsets: "greek-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
+source {
+  repository_url: "https://github.com/googlefonts/zen-dots"
+  commit: "aa0a34abc0b8ed1c50bfabafc3ce0531be020e56"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "fonts/ttf/ZenDots-Regular.ttf"
+    dest_file: "ZenDots-Regular.ttf"
+  }
+  branch: "main"
+}
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/googlefonts/zen-dots at commit https://github.com/googlefonts/zen-dots/commit/aa0a34abc0b8ed1c50bfabafc3ce0531be020e56.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
