### PR TITLE
Monomaniac One: Version 1.000; ttfautohint (v1.8.3) added



### DIFF
--- a/ofl/monomaniacone/DESCRIPTION.en_us.html
+++ b/ofl/monomaniacone/DESCRIPTION.en_us.html
@@ -1,5 +1,8 @@
 <p>
-Monomaniac is a bold Japanese Sans Serif font featuring rounded corners. The letterforms are condensed which work well for vertical typesetting.
+Newly designed only for Google Fonts: bold rounded Japanese Sans Serif font. All the corners are roundly designed. This font is designed condensed letterform to best-fit for vertical typesetting.
+</p>
+<p>
+This font is designed condensed letterform to best-fit for vertical typesetting.
 </p>
 <p>
 To contribute to the project, visit <a href="https://github.com/ManiackersDesign/monomaniac">github.com/ManiackersDesign/monomaniac</a>

--- a/ofl/monomaniacone/METADATA.pb
+++ b/ofl/monomaniacone/METADATA.pb
@@ -12,12 +12,30 @@ fonts {
   full_name: "Monomaniac One Regular"
   copyright: "Copyright 2020 The Monomaniac Project Authors (https://github.com/ManiackersDesign/monomaniac), all rights reserved."
 }
+subsets: "greek-ext"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
-languages: "ja_Kana"
-languages: "ja_Hira"
+source {
+  repository_url: "https://github.com/ManiackersDesign/monomaniac"
+  commit: "2318283d6dbf3cbe50e8eed3c75a17a425e6bd8c"
+  files {
+    source_file: "fonts/ttf/MonomaniacOne-Regular.ttf"
+    dest_file: "MonomaniacOne-Regular.ttf"
+  }
+  files {
+    source_file: "ofl.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  branch: "master"
+}
+languages: "ja_Kana"  # Japanese, Katakana
+languages: "ja_Hira"  # Japanese, Hiragana
 primary_script: "Hira"
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/monomaniacone/OFL.txt
+++ b/ofl/monomaniacone/OFL.txt
@@ -1,93 +1,184 @@
 Copyright 2020 The Monomaniac Project Authors (https://github.com/ManiackersDesign/monomaniac), all rights reserved.
 
-This Font Software is licensed under the SIL Open Font License, Version 1.1.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.0.
+
 This license is copied below, and is also available with a FAQ at:
+
 http://scripts.sil.org/OFL
 
 
+
+
+
 -----------------------------------------------------------
-SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+
+SIL OPEN FONT LICENSE Version 1.0 - 31 February 2007
+
 -----------------------------------------------------------
+
+
 
 PREAMBLE
+
 The goals of the Open Font License (OFL) are to stimulate worldwide
+
 development of collaborative font projects, to support the font creation
+
 efforts of academic and linguistic communities, and to provide a free and
+
 open framework in which fonts may be shared and improved in partnership
+
 with others.
 
+
+
 The OFL allows the licensed fonts to be used, studied, modified and
+
 redistributed freely as long as they are not sold by themselves. The
-fonts, including any derivative works, can be bundled, embedded, 
+
+fonts, including any derivative works, can be bundled, embedded,
+
 redistributed and/or sold with any software provided that any reserved
+
 names are not used by derivative works. The fonts and derivatives,
+
 however, cannot be released under any other type of license. The
+
 requirement for fonts to remain under this license does not apply
+
 to any document created using the fonts or their derivatives.
 
+
+
 DEFINITIONS
+
 "Font Software" refers to the set of files released by the Copyright
+
 Holder(s) under this license and clearly marked as such. This may
+
 include source files, build scripts and documentation.
 
+
+
 "Reserved Font Name" refers to any names specified as such after the
+
 copyright statement(s).
 
+
+
 "Original Version" refers to the collection of Font Software components as
+
 distributed by the Copyright Holder(s).
 
+
+
 "Modified Version" refers to any derivative made by adding to, deleting,
+
 or substituting -- in part or in whole -- any of the components of the
+
 Original Version, by changing formats or by porting the Font Software to a
+
 new environment.
 
+
+
 "Author" refers to any designer, engineer, programmer, technical
+
 writer or other person who contributed to the Font Software.
 
+
+
 PERMISSION & CONDITIONS
+
 Permission is hereby granted, free of charge, to any person obtaining
+
 a copy of the Font Software, to use, study, copy, merge, embed, modify,
+
 redistribute, and sell modified and unmodified copies of the Font
+
 Software, subject to the following conditions:
 
+
+
 1) Neither the Font Software nor any of its individual components,
+
 in Original or Modified Versions, may be sold by itself.
 
+
+
 2) Original or Modified Versions of the Font Software may be bundled,
+
 redistributed and/or sold with any software, provided that each copy
+
 contains the above copyright notice and this license. These can be
+
 included either as stand-alone text files, human-readable headers or
+
 in the appropriate machine-readable metadata fields within text or
+
 binary files as long as those fields can be easily viewed by the user.
 
+
+
 3) No Modified Version of the Font Software may use the Reserved Font
+
 Name(s) unless explicit written permission is granted by the corresponding
+
 Copyright Holder. This restriction only applies to the primary font name as
+
 presented to the users.
 
+
+
 4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+
 Software shall not be used to promote, endorse or advertise any
+
 Modified Version, except to acknowledge the contribution(s) of the
+
 Copyright Holder(s) and the Author(s) or with their explicit written
+
 permission.
 
+
+
 5) The Font Software, modified or unmodified, in part or in whole,
+
 must be distributed entirely under this license, and must not be
+
 distributed under any other license. The requirement for fonts to
+
 remain under this license does not apply to any document created
+
 using the Font Software.
 
+
+
 TERMINATION
+
 This license becomes null and void if any of the above conditions are
+
 not met.
 
+
+
 DISCLAIMER
+
 THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+
 EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+
 MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+
 OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+
 COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+
 INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+
 DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+
 FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+
 OTHER DEALINGS IN THE FONT SOFTWARE.


### PR DESCRIPTION
Taken from the upstream repo https://github.com/ManiackersDesign/monomaniac at commit https://github.com/ManiackersDesign/monomaniac/commit/2318283d6dbf3cbe50e8eed3c75a17a425e6bd8c.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
