### PR TITLE
Moirai One: Version 1.000; ttfautohint (v1.8.4.7-5d5b);gftools[0.9.29] added



### DIFF
--- a/ofl/moiraione/DESCRIPTION.en_us.html
+++ b/ofl/moiraione/DESCRIPTION.en_us.html
@@ -2,6 +2,9 @@
     Moirai is a font that experiments with stroke movement with visibility and legibility. It is designed to draw, arrange, and delete strokes of letters to have the minimum strokes and slopes necessary for that letter to be recognized. The shapes surrounding the thick space with thin, round lines give a lovely impression, while also creating a light and lyrical atmosphere.
 </p>
 <p>
+    JAMO is a type design collective group based in Seoul, Korea. We provide professional education, information, and discussion to designers who are wishing to develop their own typefaces through our workshop. JAMO encourages more experimental and unconventional typeface design by getting inspirations from old types, finding an alternative usage from existing ones, and suggesting new letterforms for the future. We aim to escape from the passive practice and create more self-initiating active typefaces. JAMO offers high-quality typeface design based on the deep levels of research, planning, and study. By broadening the potential of Hangul, we propose a new type design methodology to co-live with other worldwide letters including the Latin Alphabet.
+</p>
+<p>
     To contribute, please visit <a
-        href="https://github.com/JAMO-TYPEFACE/Moirai">github.com/JAMO-TYPEFACE/Moirai</a>.
+        href="https://github.com/JAMO-TYPEFACE/Moirai">https://github.com/JAMO-TYPEFACE/Moirai</a>.
 </p>

--- a/ofl/moiraione/METADATA.pb
+++ b/ofl/moiraione/METADATA.pb
@@ -18,6 +18,19 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/JAMO-TYPEFACE/Moirai"
-  commit: "3220f0c211c8d3a3bb989896cf7ea66d16a925e6"
+  commit: "2da483959021f384eebc39feb6da1e8cbcdf452d"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "Fonts/ttf/MoiraiOne-Regular.ttf"
+    dest_file: "MoiraiOne-Regular.ttf"
+  }
+  branch: "main"
 }
 primary_script: "Kore"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/JAMO-TYPEFACE/Moirai at commit https://github.com/JAMO-TYPEFACE/Moirai/commit/2da483959021f384eebc39feb6da1e8cbcdf452d.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
