### PR TITLE
Lavishly Yours: Version 1.010; ttfautohint (v1.8.3) added



### DIFF
--- a/ofl/lavishlyyours/DESCRIPTION.en_us.html
+++ b/ofl/lavishlyyours/DESCRIPTION.en_us.html
@@ -1,5 +1,5 @@
 <p>
-One of the first fonts to use ornately embellished capital forms, Lavishly Yours is a charming calligraphic script. Its nearly upright style along with looped lowercase miniscules gives this font a fairly tale look.
+One of the first fonts to use ornately embellished capital forms, Lavishly Yours is a charming calligraphic script. It's nearly upright style along with looped lowercase miniscules gives this font a fairly tale look.
 </p>
 <p>
 It comes with Latin Character sets including Western, Central, and Vietnamese language support.

--- a/ofl/lavishlyyours/METADATA.pb
+++ b/ofl/lavishlyyours/METADATA.pb
@@ -12,6 +12,8 @@ fonts {
   full_name: "Lavishly Yours Regular"
   copyright: "Copyright 2014-2021 The Lavishly Yours Project Authors (https://github.com/googlefonts/lavishly-yours)"
 }
+subsets: "cyrillic-ext"
+subsets: "greek-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
@@ -19,6 +21,19 @@ subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/lavishly-yours"
   commit: "06ea77a251dc2d763d199995ec06da0a0c1a85f1"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "documentation/DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "fonts/ttf/LavishlyYours-Regular.ttf"
+    dest_file: "LavishlyYours-Regular.ttf"
+  }
+  branch: "master"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/googlefonts/lavishly-yours at commit https://github.com/googlefonts/lavishly-yours/commit/06ea77a251dc2d763d199995ec06da0a0c1a85f1.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
