### PR TITLE
Atkinson Hyperlegible: Version 1.006; ttfautohint (v1.8.3) added



### DIFF
--- a/ofl/atkinsonhyperlegible/DESCRIPTION.en_us.html
+++ b/ofl/atkinsonhyperlegible/DESCRIPTION.en_us.html
@@ -1,12 +1,8 @@
 <p>
-    Atkinson Hyperlegible, named after the founder of the Braille Institute, has been developed specifically to increase legibility for readers with low vision, and to improve comprehension.
+Atkinson Hyperlegible, named after the founder of the Braille Institute, has been developed specifically to increase legibility for readers with low vision, and to improve comprehension.
 </p>
 <p>
-    Having a traditional grotesque sans-serif at its core, it departs from tradition to incorporate unambiguous, distinctive elements—and at times, unexpected forms—always with the goal of increasing character recognition and ultimately improve reading.
+Having a traditional grotesque sans-serif at its core, it departs from tradition to incorporate unambiguous, distinctive elements—and at times, unexpected forms—always with the goal of increasing character recognition and ultimately improve reading.
 </p>
-<p>
-    To contribute, see <a href="https://github.com/googlefonts/atkinson-hyperlegible">github.com/googlefonts/atkinson-hyperlegible</a>.
-</p>
-<p>
-    To learn more, read <a href="https://material.io/blog/atkinson-hyperlegible-design">From Rebranding to Readability with Atkinson Hyperlegible</a>.
+<p>To contribute, see <a href="https://github.com/googlefonts/atkinson-hyperlegible" target="_blank">github.com/googlefonts/atkinson-hyperlegible</a>.
 </p>

--- a/ofl/atkinsonhyperlegible/METADATA.pb
+++ b/ofl/atkinsonhyperlegible/METADATA.pb
@@ -39,6 +39,36 @@ fonts {
   full_name: "Atkinson Hyperlegible Bold Italic"
   copyright: "Copyright 2020 Braille Institute of America, Inc."
 }
+subsets: "greek-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
+source {
+  repository_url: "https://github.com/googlefonts/atkinson-hyperlegible"
+  commit: "1cb311624b2ddf88e9e37873999d165a8cd28b46"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "fonts/ttf/AtkinsonHyperlegible-Regular.ttf"
+    dest_file: "AtkinsonHyperlegible-Regular.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/AtkinsonHyperlegible-Bold.ttf"
+    dest_file: "AtkinsonHyperlegible-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/AtkinsonHyperlegible-Italic.ttf"
+    dest_file: "AtkinsonHyperlegible-Italic.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/AtkinsonHyperlegible-BoldItalic.ttf"
+    dest_file: "AtkinsonHyperlegible-BoldItalic.ttf"
+  }
+  branch: "main"
+}


### PR DESCRIPTION
Taken from the upstream repo https://github.com/googlefonts/atkinson-hyperlegible at commit https://github.com/googlefonts/atkinson-hyperlegible/commit/1cb311624b2ddf88e9e37873999d165a8cd28b46.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
