### PR TITLE
Zen Maru Gothic: Version 1.001 added



### DIFF
--- a/ofl/zenmarugothic/DESCRIPTION.en_us.html
+++ b/ofl/zenmarugothic/DESCRIPTION.en_us.html
@@ -1,17 +1,6 @@
 <p>
-    Zen Maru Gothic is a rounded san serif family that gives a soft and natural impression due to the deep rounds in the corners. Because of this unique soft impression the thin weight is also easy to use in any scenes. Cute and fashionable, soft and easy
-    for any communications.
+    Zen Maru Gothic is a rounded san serif family that gives a soft and natural impression due to the deep rounds in the corners. Because of this unique soft impression the thin weight is also easy to use in any scenes. Cute and fashionable, soft and easy for any communications.
 </p>
 <p>
-    To contribute to the project, visit <a href="https://github.com/googlefonts/zen-marugothic">https://github.com/googlefonts/zen-marugothic</a>
-</p>
-<p>
-    Zen Maru Gothicは、角の深い丸みによってソフトでナチュラルな印象を与える丸ゴシック体です。この特有のソフトな印象により、細いウエイトはどのようなシーンにも似合います。キュートでオシャレなこのフォントは、様々な場面で柔らかくふんわりとしたコミュニケーションに活用できます。
-</p>
-<p>
-    このプロジェクトに参加するには、こちらのリンクへ https://github.com/googlefonts/zen-marugothic
-</p>
-<p>
-    To learn more, read <a href="https://fonts.googleblog.com/2021/10/say-hello-to-our-big-new-japanese.html">Say Hello to our big new Japanese collection with Zen Fonts</a>(English), <a href="https://fonts.googleblog.com/2021/10/the-story-of-zen-fonts-interview-with.html">The Story of Zen Fonts - interview with Yoshimichi Ohira</a>(English),
-    <a href="https://fonts.googleblog.com/2021/10/zen_0361327225.html">Zenフォント: 新しい日本語フォントコレクションの登場 - 日本語フォントの複雑な美しさについて -</a>(Japanese), and <a href="https://fonts.googleblog.com/2021/10/Japaneseinterview.html">Zenフォントのおはなし：大平善道さんとのインタビュー</a>(Japanese).
+To contribute to the project, visit <a href="https://github.com/googlefonts/zen-marugothic">https://github.com/googlefonts/zen-marugothic</a>
 </p>

--- a/ofl/zenmarugothic/METADATA.pb
+++ b/ofl/zenmarugothic/METADATA.pb
@@ -48,12 +48,48 @@ fonts {
   full_name: "Zen Maru Gothic Black"
   copyright: "Copyright 2021 The Zen Maru Gothic Authors (https://github.com/googlefonts/zen-marugothic)"
 }
+subsets: "chinese-hongkong"
+subsets: "chinese-simplified"
+subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "greek"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
+source {
+  repository_url: "https://github.com/googlefonts/zen-marugothic"
+  commit: "decae11c15a25910ded2a06a9d27ee01c4addc76"
+  files {
+    source_file: "fonts/ttf/ZenMaruGothic-Light.ttf"
+    dest_file: "ZenMaruGothic-Light.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/ZenMaruGothic-Regular.ttf"
+    dest_file: "ZenMaruGothic-Regular.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/ZenMaruGothic-Medium.ttf"
+    dest_file: "ZenMaruGothic-Medium.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/ZenMaruGothic-Bold.ttf"
+    dest_file: "ZenMaruGothic-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/ZenMaruGothic-Black.ttf"
+    dest_file: "ZenMaruGothic-Black.ttf"
+  }
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  branch: "main"
+}
 primary_script: "Jpan"
 stroke: "SERIF"
 classifications: "DISPLAY"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/googlefonts/zen-marugothic at commit https://github.com/googlefonts/zen-marugothic/commit/decae11c15a25910ded2a06a9d27ee01c4addc76.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
