### PR TITLE
Alexandria: Version 5.100 added



### DIFF
--- a/ofl/alexandria/DESCRIPTION.en_us.html
+++ b/ofl/alexandria/DESCRIPTION.en_us.html
@@ -1,25 +1,12 @@
 <p>
-    Alexandria is the Arabic companion of <a href="https://fonts.google.com/specimen/Montserrat">Montserrat</a>, 
-    a Latin script typeface designed by Julieta Ulanovsky which was inspired by the old posters and signs in the 
-    traditional Montserrat neighborhood of Buenos Aires.
+    Alexandria is a 9 weights font family made in matching to the Latin <a
+        href="https://fonts.google.com/specimen/Montserrat">Montserrat</a> by Julieta Ulanovsky which was
+    inspired by the old posters and signs in the traditional Montserrat neighborhood of Buenos Aires.
 </p>
 <p>
-    Alexandria is a variable font ranging from Thin to Black, increasing the ability to use the font in various applications, from long text
+    Having the font family of nine weights increases the ability to use the font in various applications, from long text
     using the light weights to short headlines using the heavy thick weights.
 </p>
-
-<p dir="rtl" lang="ar">
-خط الإسكندرية العربي هو عائلة خط من ٩ أوزان مصنوع في مزاوجة خطيّة مع الخط اللاتيني
-مونتسرات من تصميم جوليا ألانوفسكي مستوحياه من تصميمات للواصق ولوح قديمة في
-شوارع حي مونتسرات في بينوس آيريس.
-</p>
-
-<p dir="rtl" lang="ar">
-كون العائلة الخطية مكوّنة من ٩ أوزان يزيد ذلك من قدرات استخدام الخط في تطبيقات
-متنوعة، من خط مناسب للكتل النصية الطويلة عند استخدام الوزن الخفيف، لمناسبته للنصوص
-القصيرة مثل العناوين والتي يناسبها استخدام الأوزان السميكة من الخط.
-</p>
-
 <p>
-    To contribute, see <a href="https://github.com/Gue3bara/Alexandria">github.com/Gue3bara/Alexandria</a>.
+    To contribute, see <a href="https://github.com/Gue3bara/Alexandria">github.com/Gue3bara/Alexandria</a> page.
 </p>

--- a/ofl/alexandria/METADATA.pb
+++ b/ofl/alexandria/METADATA.pb
@@ -13,6 +13,7 @@ fonts {
   copyright: "Copyright 2022 The Alexandria Project Authors (https://github.com/Gue3bara/Alexandria)"
 }
 subsets: "arabic"
+subsets: "greek-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
@@ -24,6 +25,19 @@ axes {
 }
 source {
   repository_url: "https://github.com/Gue3bara/Alexandria"
-  commit: "cee89798e4b38c8df61477a646aa9c111314e6ae"
+  commit: "4fd1422be3488837c41fbdb84a77350f0f56a734"
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/variable/Alexandria[wght].ttf"
+    dest_file: "Alexandria[wght].ttf"
+  }
+  branch: "master"
 }
 primary_script: "Arab"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/Gue3bara/Alexandria at commit https://github.com/Gue3bara/Alexandria/commit/4fd1422be3488837c41fbdb84a77350f0f56a734.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
