### PR TITLE
Darumadrop One: Version 1.000 added



### DIFF
--- a/ofl/darumadropone/DESCRIPTION.en_us.html
+++ b/ofl/darumadropone/DESCRIPTION.en_us.html
@@ -1,5 +1,5 @@
 <p>
-Darumdrop is a flavorful handwritten font inspired by Japanese handwriting and "Daruma Otoshi" which is a Japanese folk craft game.
+Newly designed only for Google Fonts: flavorful and Japanese cultural handwritten font. The name Darumdrop means Japanese folk craft toy "Daruma otoshi." This font is designed with the themes of folk craft, traditional craft, Showa, zen, Japanese culture, etc.
 </p>
 <p>
 To contribute to the project, visit <a href="https://github.com/ManiackersDesign/darumadrop">github.com/ManiackersDesign/darumadrop</a>

--- a/ofl/darumadropone/METADATA.pb
+++ b/ofl/darumadropone/METADATA.pb
@@ -12,12 +12,30 @@ fonts {
   full_name: "Darumadrop One Regular"
   copyright: "Copyright 2020 The Darumadrop Project Authors (https://github.com/ManiackersDesign/darumadrop), all rights reserved."
 }
+subsets: "greek-ext"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
-languages: "ja_Kana"
-languages: "ja_Hira"
+source {
+  repository_url: "https://github.com/ManiackersDesign/darumadrop"
+  commit: "ddbe82834bdab1ecc24adad09cc122d6e8678a81"
+  files {
+    source_file: "fonts/ttf/DarumadropOne-Regular.ttf"
+    dest_file: "DarumadropOne-Regular.ttf"
+  }
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "DESCRIPTION.en_us.html"
+    dest_file: "DESCRIPTION.en_us.html"
+  }
+  branch: "master"
+}
+languages: "ja_Kana"  # Japanese, Katakana
+languages: "ja_Hira"  # Japanese, Hiragana
 primary_script: "Hira"
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/darumadropone/OFL.txt
+++ b/ofl/darumadropone/OFL.txt
@@ -1,4 +1,4 @@
-Copyright 2020 The Darumadrop One Project Authors (https://github.com/ManiackersDesign/darumadrop)
+Copyright 2020 The Darumadrop Project Authors (https://github.com/ManiackersDesign/darumadrop)
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:


### PR DESCRIPTION
Taken from the upstream repo https://github.com/ManiackersDesign/darumadrop at commit https://github.com/ManiackersDesign/darumadrop/commit/ddbe82834bdab1ecc24adad09cc122d6e8678a81.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] Minisite_url definition in the METADATA.pb file for commissioned projects
- [ ] Primary_script definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
